### PR TITLE
fix module

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 import { ModuleContext } from "./types";
-export { UA } from "./plugin.template";
 
 module.exports = function nuxtUserAgent() {
   const _this: ModuleContext = this as any; // Force cast this context.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "strict": true,
     "target": "es5",
-    "module": "es2015",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "lib": ["esnext", "dom"],
     "outDir": "lib"


### PR DESCRIPTION
Hi. Two fixes:

- Nuxt loads modules through `esm` loader however it is not a valid es syntax to mix `import`, `export` with `require` and `module`
- Modules should not expose anything from the plugin template. Plugins are being copied to the project and build with webpack.

fixes #18.