### PR TITLE
fix: don't publish examples

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+examples/
 src/
 tsconfig.json
 tslint.json


### PR DESCRIPTION
Currently published version includes examples and all build files
created for those for use when testing. That makes the unpacked
package's size to be around 120MB. Fix by not incuding examples
directory.